### PR TITLE
Adding in tryFetch, tryFetchAs, and tryPostRecord

### DIFF
--- a/src/Fable.PowerPack.fsproj
+++ b/src/Fable.PowerPack.fsproj
@@ -42,8 +42,8 @@
     <Reference Include="../node_modules/fable-core/Fable.Core.dll" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Promise.fs" />
     <Compile Include="Result.fs" />
+    <Compile Include="Promise.fs" />
     <Compile Include="Fetch.fs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />

--- a/src/Fable.PowerPack.fsproj
+++ b/src/Fable.PowerPack.fsproj
@@ -43,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Promise.fs" />
+    <Compile Include="Result.fs" />
     <Compile Include="Fetch.fs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />

--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -41,7 +41,7 @@ module Promise =
     let Parallel (pr: seq<JS.Promise<'T>>): JS.Promise<'T[]> = jsNative
 
     let result (a: JS.Promise<'A>): JS.Promise<Result<'A, Exception>> =
-        either Success Error a
+        either Ok Error a
 
     let mapResult (fn: 'A -> 'B) (a: JS.Promise<Result<'A, 'E>>): JS.Promise<Result<'B, 'E>> =
         a |> map (Result.map fn)
@@ -49,7 +49,7 @@ module Promise =
     let bindResult (fn: 'A -> JS.Promise<'B>) (a: JS.Promise<Result<'A, Exception>>): JS.Promise<Result<'B, Exception>> =
         a |> bind (fun a ->
             match a with
-            | Success a ->
+            | Ok a ->
                 result (fn a)
             | Error e ->
                 lift (Error e))

--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -8,6 +8,7 @@ module Promise =
     open Fable.Core
     open Fable.Import
     open Fable.Core.JsInterop
+    open Fable.PowerPack.Result
 
     let inline private (!!) (x:obj): 'T = unbox x
 
@@ -38,6 +39,20 @@ module Promise =
 
     [<Emit("Promise.all($0)")>]
     let Parallel (pr: seq<JS.Promise<'T>>): JS.Promise<'T[]> = jsNative
+
+    let result (a: JS.Promise<'A>): JS.Promise<Result<'A, Exception>> =
+        either Success Error a
+
+    let mapResult (fn: 'A -> 'B) (a: JS.Promise<Result<'A, 'E>>): JS.Promise<Result<'B, 'E>> =
+        a |> map (Result.map fn)
+
+    let bindResult (fn: 'A -> JS.Promise<'B>) (a: JS.Promise<Result<'A, Exception>>): JS.Promise<Result<'B, Exception>> =
+        a |> bind (fun a ->
+            match a with
+            | Success a ->
+                result (fn a)
+            | Error e ->
+                lift (Error e))
 
     type PromiseBuilder() =
         [<Emit("$1.then($2)")>]

--- a/src/Result.fs
+++ b/src/Result.fs
@@ -1,0 +1,47 @@
+module Fable.PowerPack.Result
+
+
+type Result<'A, 'B> =
+| Success of 'A
+| Error of 'B
+
+
+let unwrapResult a =
+    match a with
+    | Success a -> a
+    | Error b -> raise b
+
+
+let map fn a =
+    match a with
+    | Success a -> Success (fn a)
+    | Error b -> Error b
+
+
+let bind fn a =
+    match a with
+    | Success a -> fn a
+    | Error b -> Error b
+
+
+// TODO implement TryFinally, TryWith, Using, While, and For ?
+type ResultBuilder() =
+    member this.Bind(m, f) = bind f m
+    member this.Return<'A, 'E>(a: 'A): Result<'A, 'E> = Success a
+    member this.ReturnFrom(m) = m
+    member this.Zero = this.Return
+
+    member this.Combine<'A, 'E>(left: Result<unit, 'E>, right: Result<'A, 'E>): Result<'A, 'E> =
+        this.Bind(left, fun () -> right)
+
+    (*member this.For<'A, 'E>(s: seq<'A>, fn: ('A -> Result<unit, 'E>)): Result<unit, 'E> =
+        let error = Seq.tryFind (fun a ->
+            match fn a with
+            | Success () -> false
+            | Error _ -> true) s
+
+        match error with
+        | Some e -> e
+        | None -> this.Zero()*)
+
+let result = new ResultBuilder()

--- a/src/Result.fs
+++ b/src/Result.fs
@@ -1,33 +1,36 @@
 module Fable.PowerPack.Result
 
 
+// TODO replace this with F# 4.1 Result
 type Result<'A, 'B> =
-| Success of 'A
+| Ok of 'A
 | Error of 'B
 
 
 let unwrapResult a =
     match a with
-    | Success a -> a
+    | Ok a -> a
     | Error b -> raise b
 
 
+// TODO replace this with F# 4.1 map
 let map fn a =
     match a with
-    | Success a -> Success (fn a)
+    | Ok a -> Ok (fn a)
     | Error b -> Error b
 
 
+// TODO replace this with F# 4.1 bind
 let bind fn a =
     match a with
-    | Success a -> fn a
+    | Ok a -> fn a
     | Error b -> Error b
 
 
 // TODO implement TryFinally, TryWith, Using, While, and For ?
 type ResultBuilder() =
     member this.Bind(m, f) = bind f m
-    member this.Return<'A, 'E>(a: 'A): Result<'A, 'E> = Success a
+    member this.Return<'A, 'E>(a: 'A): Result<'A, 'E> = Ok a
     member this.ReturnFrom(m) = m
     member this.Zero = this.Return
 
@@ -37,7 +40,7 @@ type ResultBuilder() =
     (*member this.For<'A, 'E>(s: seq<'A>, fn: ('A -> Result<unit, 'E>)): Result<unit, 'E> =
         let error = Seq.tryFind (fun a ->
             match fn a with
-            | Success () -> false
+            | Ok () -> false
             | Error _ -> true) s
 
         match error with

--- a/tests/FetchTests.fsx
+++ b/tests/FetchTests.fsx
@@ -7,6 +7,7 @@ open Fable.Core.JsInterop
 open Fable.Import
 open Fable.PowerPack
 open Fable.PowerPack.Fetch
+open Fable.PowerPack.Result
 
 let inline equal (expected: 'T) (actual: 'T): unit =
     let assert' = importAll<obj> "assert"
@@ -18,7 +19,7 @@ let it (msg: string) (f: unit->JS.Promise<'T>): unit = jsNative
 // Fetch polyfill for node
 JsInterop.importAll "isomorphic-fetch"
 
-it "Fetch requests work" <| fun () ->
+it "fetch: requests work" <| fun () ->
     let getWebPageLength url =
         fetch url []
         |> Promise.bind (fun res -> res.text())
@@ -26,7 +27,7 @@ it "Fetch requests work" <| fun () ->
     getWebPageLength "http://fable.io"
     |> Promise.map (fun res -> res > 0 |> equal true)
 
-it "Parallel fetch requests work" <| fun () ->
+it "fetch: parallel requests work" <| fun () ->
     let getWebPageLength url =
         promise {
             let! res = fetch url []
@@ -42,13 +43,30 @@ it "Parallel fetch requests work" <| fun () ->
     // expected to be bigger than 100 characters
     |> Promise.map (fun results -> (Array.sum results) > 100 |> equal true)
 
-it "Unsuccessful HTTP status codes throw an error" <| fun () ->
+it "fetch: unsuccessful HTTP status codes throw an error" <| fun () ->
     promise {
         let! res = fetch "http://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it" []
         let! txt = res.text()
         return txt
     }
-    |> Promise.map id
     |> Promise.catch (fun e -> e.Message)
     |> Promise.map (fun results ->
-         results |> equal "404 Not Found for URL http://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
+        results |> equal "404 Not Found for URL http://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
+
+it "tryFetch: unsuccessful HTTP status codes returns an Error" <| fun () ->
+    tryFetch "http://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it" []
+    |> Promise.map (fun a ->
+        match a with
+        | Success a -> "failed"
+        | Error e -> e.Message)
+    |> Promise.map (fun results ->
+        results |> equal "404 Not Found for URL http://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
+
+it "tryFetch: exceptions return an Error" <| fun () ->
+    tryFetch "http://this-must-be-an-invalid-url-no-really-i-mean-it.com" []
+    |> Promise.map (fun a ->
+        match a with
+        | Success a -> "failed"
+        | Error e -> e.Message)
+    |> Promise.map (fun results ->
+        results |> equal "request to http://this-must-be-an-invalid-url-no-really-i-mean-it.com failed, reason: getaddrinfo ENOTFOUND this-must-be-an-invalid-url-no-really-i-mean-it.com this-must-be-an-invalid-url-no-really-i-mean-it.com:80")

--- a/tests/FetchTests.fsx
+++ b/tests/FetchTests.fsx
@@ -57,7 +57,7 @@ it "tryFetch: unsuccessful HTTP status codes returns an Error" <| fun () ->
     tryFetch "http://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it" []
     |> Promise.map (fun a ->
         match a with
-        | Success a -> "failed"
+        | Ok a -> "failed"
         | Error e -> e.Message)
     |> Promise.map (fun results ->
         results |> equal "404 Not Found for URL http://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
@@ -66,7 +66,7 @@ it "tryFetch: exceptions return an Error" <| fun () ->
     tryFetch "http://this-must-be-an-invalid-url-no-really-i-mean-it.com" []
     |> Promise.map (fun a ->
         match a with
-        | Success a -> "failed"
+        | Ok a -> "failed"
         | Error e -> e.Message)
     |> Promise.map (fun results ->
         results |> equal "request to http://this-must-be-an-invalid-url-no-really-i-mean-it.com failed, reason: getaddrinfo ENOTFOUND this-must-be-an-invalid-url-no-really-i-mean-it.com this-must-be-an-invalid-url-no-really-i-mean-it.com:80")


### PR DESCRIPTION
Also added in a new `Result` type which allows for type-safe error handling.