### PR TITLE
Add Promise.start to the promise module

### DIFF
--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -37,6 +37,9 @@ module Promise =
     [<Emit("$2.then($0,$1)")>]
     let either (success: 'T->'R) (fail: Exception->'R) (pr: JS.Promise<'T>): JS.Promise<'R> = jsNative
 
+    [<Emit("$0.then(function(v){v;})")>]
+    let start (pr: JS.Promise<'T>): unit = jsNative
+
     [<Emit("Promise.all($0)")>]
     let Parallel (pr: seq<JS.Promise<'T>>): JS.Promise<'T[]> = jsNative
 


### PR DESCRIPTION
As talked about on gitter, not named `makeitdoshit`.

I looked at what fable actually compiled `ignore` to and it seems like what ended up in javascript was `function(value) { value; }` so I used that as the argument for then. Not sure if thats the best, but something has to be in there...