### PR TITLE
WIP: Add EventSource type

### DIFF
--- a/src/EventSource.fs
+++ b/src/EventSource.fs
@@ -1,0 +1,19 @@
+namespace Fable.PowerPack
+
+#nowarn "1182" // Unused values
+
+[<RequireQualifiedAccess>]
+module EventSouce =
+    open System
+    open Fable.Core
+
+    type Event =
+        abstract data: string with get
+
+    type EventSource =
+        abstract onmessage: (Event -> unit) with get, set
+
+    [<Emit("new EventSource($0)")>]
+    /// The promise function receives two other function parameters: success and fail
+    let create (location: string): EventSource = jsNative
+

--- a/src/Fable.PowerPack.fsproj
+++ b/src/Fable.PowerPack.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="PromiseSeq/Extensions.fs" />
     <Compile Include="Fetch.fs" />
     <Compile Include="IndexedDB.fs" />
+    <Compile Include="EventSource.fs">
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Choose>


### PR DESCRIPTION
This is totally work in progress but I wanted to get feedback if this is even right place and/or way to do such things. 

I saw that the EventSource type was missing in fable and since or frontend uses server sent events I wanted to make it work with fable. 

Is the powerpack the right place or should this go into the Import JS part of fables main repo?