### PR TITLE
Generate XML documentation file

### DIFF
--- a/Fable.PowerPack.fsproj
+++ b/Fable.PowerPack.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Version>1.1.2</Version>
     <TargetFramework>netstandard1.6</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="src/Result.fs" />


### PR DESCRIPTION
This lets the toolchain generate the XML documentation file. `dotnet pack` automatically picks it up and embeds it into the package.