### PR TITLE
Fixes to indexedDB and promise test

### DIFF
--- a/tests/PromiseTests.fs
+++ b/tests/PromiseTests.fs
@@ -249,8 +249,8 @@ describe "Promise tests" <| fun _ ->
 
             let! r1 = successful |> Promise.either (fun x -> !^(string x)) (fun x -> failwith "Shouldn't get called")
             let! r2 = successful |> Promise.either (fun x -> !^(Promise.lift <| string x)) (fun x -> failwith "Shouldn't get called")
-            let! r3 = failing |> Promise.either (fun x -> failwith "Shouldn't get called") (fun ex -> !^ex.Message)
-            let! r4 = failing |> Promise.either (fun x -> failwith "Shouldn't get called") (fun ex -> !^(Promise.lift ex.Message))
+            let! r3 = failing |> Promise.either (fun x -> failwith "Shouldn't get called") (fun (ex:Exception) -> !^ex.Message)
+            let! r4 = failing |> Promise.either (fun x -> failwith "Shouldn't get called") (fun (ex:Exception) -> !^(Promise.lift ex.Message))
 
             r1 |> equal "42"
             r2 |> equal "42"


### PR DESCRIPTION
Related to issue https://github.com/fable-compiler/Fable/issues/1174

The comment:

https://github.com/fable-compiler/Fable/issues/1174#issuecomment-341038069

Fixed:

Calling index.openCursor and index.openKeyCursor with first optional argument:

`index.openCursor(?range=None, direction=direction)`

And fixed failing promise test:

`error FSHARP: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
`

