### PR TITLE
Added new BrowserStorage module

### DIFF
--- a/Fable.PowerPack.fsproj
+++ b/Fable.PowerPack.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="src/IndexedDB.fs" />
     <Compile Include="src/Date/Local.fs" />
     <Compile Include="src/Date/Format.fs" />
+    <Compile Include="src/BrowserStorage.fs" />
     <Compile Include="src/BrowserLocalStorage.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/Fable.PowerPack.fsproj
+++ b/Fable.PowerPack.fsproj
@@ -17,9 +17,6 @@
     <Compile Include="src/Date/Local.fs" />
     <Compile Include="src/Date/Format.fs" />
     <Compile Include="src/BrowserStorage.fs" />
-    <!-->
-    <Compile Include="src/BrowserLocalStorage.fs" />
-    -->
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj" PackagePath="fable\" />

--- a/Fable.PowerPack.fsproj
+++ b/Fable.PowerPack.fsproj
@@ -17,7 +17,9 @@
     <Compile Include="src/Date/Local.fs" />
     <Compile Include="src/Date/Format.fs" />
     <Compile Include="src/BrowserStorage.fs" />
+    <!-->
     <Compile Include="src/BrowserLocalStorage.fs" />
+    -->
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj" PackagePath="fable\" />

--- a/src/BrowserStorage.fs
+++ b/src/BrowserStorage.fs
@@ -1,0 +1,28 @@
+module Fable.PowerPack.BrowserStorage
+
+open Fable.Import
+open Fable.Core.JsInterop
+
+module LocalStorage = 
+
+  let inline load<'T> key =
+      Browser.localStorage.getItem(key) |> unbox
+      |> Option.map ofJson<'T>
+
+  let inline delete key =
+      Browser.localStorage.removeItem(key)
+
+  let inline save<'T> key (data: 'T) =
+      Browser.localStorage.setItem(key, toJson data)
+
+module SessionStorage = 
+
+  let inline load<'T> key =
+      Browser.sessionStorage.getItem(key) |> unbox
+      |> Option.map ofJson<'T>
+
+  let inline delete key =
+      Browser.sessionStorage.removeItem(key)
+
+  let inline save<'T> key (data: 'T) =
+      Browser.sessionStorage.setItem(key, toJson data)

--- a/src/BrowserStorage.fs
+++ b/src/BrowserStorage.fs
@@ -1,9 +1,9 @@
-module Fable.PowerPack.BrowserStorage
+namespace Fable.PowerPack
 
 open Fable.Import
 open Fable.Core.JsInterop
 
-module LocalStorage = 
+module BrowserLocalStorage  = 
 
   let inline load<'T> key =
       Browser.localStorage.getItem(key) |> unbox
@@ -15,7 +15,7 @@ module LocalStorage =
   let inline save<'T> key (data: 'T) =
       Browser.localStorage.setItem(key, toJson data)
 
-module SessionStorage = 
+module BrowserSessionStorage  = 
 
   let inline load<'T> key =
       Browser.sessionStorage.getItem(key) |> unbox

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -263,14 +263,15 @@ module Fetch_types =
 
     [<StringEnum; RequireQualifiedAccess>]
     type HttpMethod =
+        | [<CompiledName("CONNECT")>] CONNECT
+        | [<CompiledName("DELETE")>] DELETE
         | [<CompiledName("GET")>] GET
         | [<CompiledName("HEAD")>] HEAD
+        | [<CompiledName("OPTIONS")>] OPTIONS
+        | [<CompiledName("PATCH")>] PATCH
         | [<CompiledName("POST")>] POST
         | [<CompiledName("PUT")>] PUT
-        | [<CompiledName("DELETE")>] DELETE
         | [<CompiledName("TRACE")>] TRACE
-        | [<CompiledName("CONNECT")>] CONNECT
-        | [<CompiledName("PATCH")>] PATCH
 
     type IHttpRequestHeaders =
         interface end
@@ -365,7 +366,6 @@ let  [<PassGenerics>] fetchAs<'T> (url: string) (init: RequestProperties list) :
 
 let  [<PassGenerics>] tryFetchAs<'T> (url: string) (init: RequestProperties list) : JS.Promise<Result<'T, Exception>> =
     fetchAs url init |> Promise.result
-
 
 /// Sends a HTTP post with the record serialized as JSON.
 /// This function already sets the HTTP Method to POST sets the json into the body.

--- a/tests/FetchTests.fs
+++ b/tests/FetchTests.fs
@@ -64,6 +64,28 @@ describe "Fetch tests" <| fun _ ->
         |> Promise.map (fun results ->
             results |> equal "404 Not Found for URL http://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
 
+    it "tryFetch: Successful HTTP OPTIONS request" <| fun () ->
+        let successMessage = "OPTIONS request accepted (method allowed)"
+        let props = [ RequestProperties.Method HttpMethod.OPTIONS]
+        tryFetch "http://mockbin.org/bin/042d3a8c-edee-40ae-80f3-70ece6ae247e/view" props 
+        |> Promise.map (fun a ->
+            match a with
+            | Ok _ -> successMessage
+            | Error e -> e.Message)
+        |> Promise.map (fun results ->
+            results |> equal successMessage)
+
+    it "tryFetch: Failed HTTP OPTIONS request on Fable.io server" <| fun () ->
+        let failMessage = "OPTIONS request rejected (method not allowed)"
+        let props = [ RequestProperties.Method HttpMethod.OPTIONS]
+        tryFetch "http://fable.io" props 
+        |> Promise.map (fun a ->
+            match a with
+            | Ok a -> "ohoh? Fable.io allows OPTIONS request?"
+            | Error e -> failMessage)
+        |> Promise.map (fun results ->
+            results |> equal failMessage)
+
     it "tryFetch: exceptions return an Error" <| fun () ->
         tryFetch "http://this-must-be-an-invalid-url-no-really-i-mean-it.com" []
         |> Promise.map (fun a ->

--- a/tests/FetchTests.fs
+++ b/tests/FetchTests.fs
@@ -67,7 +67,7 @@ describe "Fetch tests" <| fun _ ->
     it "tryFetch: Successful HTTP OPTIONS request" <| fun () ->
         let successMessage = "OPTIONS request accepted (method allowed)"
         let props = [ RequestProperties.Method HttpMethod.OPTIONS]
-        tryFetch "http://mockbin.org/bin/042d3a8c-edee-40ae-80f3-70ece6ae247e/view" props 
+        tryFetch "https://gandi.net" props 
         |> Promise.map (fun a ->
             match a with
             | Ok _ -> successMessage


### PR DESCRIPTION
Hi there,
since I needed to use sessionStorage in my app I decided to change the BrowserLocalStorage to a more 'generic' BrowserStorage module with two submodules: LocalStorage and SessionStorage.

So in this PR I just added this new module without deleting the old one since many projects still use it.

I don't know if the choice I made is the best one but I'm open to discuss it with you so that we can end up having SessionStorage as well in Fable Powerpack.

Thanks!