### PR TITLE
Fixed BrowserSessionStorage.save

### DIFF
--- a/src/BrowserStorage.fs
+++ b/src/BrowserStorage.fs
@@ -29,4 +29,4 @@ module BrowserSessionStorage  =
       Browser.sessionStorage.removeItem(key)
 
   let save key (data: 'T) =
-      Browser.localStorage.setItem(key, Encode.Auto.toString(0, data))
+      Browser.sessionStorage.setItem(key, Encode.Auto.toString(0, data))


### PR DESCRIPTION
`BrowserSessionStorage.save` was using `localStorage`