### PR TITLE
[Discussion] make promise CE behave like the JS promise

### DIFF
--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -125,8 +125,8 @@ module Promise =
             
             create (fun success fail ->
                 try
-                    let x = !!JS.Promise.resolve(generator())
-                    success(x)
+                    let p : JS.Promise<'T> = !!JS.Promise.resolve(generator())
+                    p?``then``(success, fail)
                 with
                   er -> fail(er)
             )

--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -122,20 +122,39 @@ module Promise =
         member x.TryWith(p: JS.Promise<'T>, catchHandler: Exception->JS.Promise<'T>): JS.Promise<'T> = jsNative
 
         member x.Delay(generator: unit->JS.Promise<'T>): JS.Promise<'T> =
+
+            // the promise should behave like a JS promise:
+            //  * NOT started immediatly, only after the first continuation has been attached.
+            //  * cached, so that if multiple continuations attach, they all get the same result.
+            let generated = lazy ( try generator() |> Ok with exn -> exn |> Error )
+
             !!createObj[
                 "then" ==> fun f1 f2 ->
-                    try generator()?``then``(f1,f2)
-                    with er ->
+
+                    let onFail er =
                         if box f2 = null
                         then !!JS.Promise.reject(er)
                         else
                             try !!JS.Promise.resolve(f2(er))
                             with er -> !!JS.Promise.reject(er)
+                    
+                    match generated.Value with
+                    | Ok g ->
+                        try g?``then``(f1,f2)
+                        with er -> onFail er
+                    | Error er -> onFail er
+
                 "catch" ==> fun f ->
-                    try generator()?catch(f)
-                    with er ->
+
+                    let onFail er =
                         try !!JS.Promise.resolve(f(er))
                         with er -> !!JS.Promise.reject(er)
+
+                    match generated.Value with
+                    | Ok g -> 
+                        try g?catch(f)
+                        with er -> onFail er
+                    | Error er -> onFail er
             ]
 
         member x.Using<'T, 'R when 'T :> IDisposable>(resource: 'T, binder: 'T->JS.Promise<'R>): JS.Promise<'R> =

--- a/tests/PromiseTests.fs
+++ b/tests/PromiseTests.fs
@@ -322,3 +322,21 @@ describe "Promise tests" <| fun _ ->
         p.``then``(fun _ -> promiseExecutionCount |> equal 1)
         p.``then``(fun _ -> promiseExecutionCount |> equal 1)
         p.``then``(fun _ -> promiseExecutionCount |> equal 1)
+
+    it "Promise is hot" <| fun () ->
+        let mutable promiseExecutionCount = 0
+
+        // start a promise
+        let _ = promise {
+            promiseExecutionCount <- promiseExecutionCount + 1
+            return 1
+        }
+        
+        // wait a bit, then check that the first promise was executed.
+        let delayed = Promise.create(fun ok er ->
+            JS.setTimeout (fun () -> ok()) 10 (* ms *) |> ignore
+        )
+
+        delayed.``then``(fun _ -> promiseExecutionCount |> equal 1)
+        
+

--- a/tests/PromiseTests.fs
+++ b/tests/PromiseTests.fs
@@ -311,3 +311,14 @@ describe "Promise tests" <| fun _ ->
             result |> equal true
             ()
         )
+
+    it "Promise does not re-execute multiple times" <| fun () ->
+        let mutable promiseExecutionCount = 0
+        let p = promise {
+            promiseExecutionCount <- promiseExecutionCount + 1
+            return 1
+        }
+        
+        p.``then``(fun _ -> promiseExecutionCount |> equal 1)
+        p.``then``(fun _ -> promiseExecutionCount |> equal 1)
+        p.``then``(fun _ -> promiseExecutionCount |> equal 1)


### PR DESCRIPTION
ref https://github.com/fable-compiler/fable-powerpack/issues/59

__EDIT:__ I got it to work:

![grafik](https://user-images.githubusercontent.com/4236651/48780842-1b036380-ecdb-11e8-835b-38f1f21a6f85.png)

---------

The object returned from ``Delay`` is unstable - querying it multiple times will execute it multiple times.

The solution is to wrap that object in ``Run``.

I chose ``Promise.Create`` as a wrapper, because that means it is a _true_ JS promise and behaves exactly the same.